### PR TITLE
Changed reserved 'init' method to "initialize" for Swift 5.x compilation

### DIFF
--- a/ZendeskConnect.podspec
+++ b/ZendeskConnect.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name              = "ZendeskConnect"
-  s.version           = "2.0.1"
+  s.version           = "2.0.2"
   s.summary           = "Better Messages for Web and Mobile Apps"
   s.description       = <<-DESC
                         Connect makes it easy to send email and mobile messages based on user actions, then test how much each message helps your business.

--- a/ZendeskConnect/ZendeskConnect/Connect.swift
+++ b/ZendeskConnect/ZendeskConnect/Connect.swift
@@ -73,7 +73,7 @@ public final class Connect: NSObject {
     /// - Returns: Returns the shared instance configured with the private key.
     @objc
     @discardableResult
-    public func `init`(privateKey: String) -> Connect {
+    public func initialize(privateKey: String) -> Connect {
         connectShadow = ConnectShadowFactory.createConnectShadow(privateKey: privateKey,
                                                                  userStorageType: UserStorage.self,
                                                                  configStorageType: ConfigStorage.self,

--- a/ZendeskConnect/ZendeskConnectSample/AppDelegate.swift
+++ b/ZendeskConnect/ZendeskConnectSample/AppDelegate.swift
@@ -25,7 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
             UNUserNotificationCenter.current().delegate = self
         }
 
-        Connect.instance.init(privateKey:"d24426956432b8bc005fff1e51dc6fcf")
+        Connect.instance.initialize(privateKey:"d24426956432b8bc005fff1e51dc6fcf")
         return true
     }
     


### PR DESCRIPTION
# Changes

## Reviewers
@zendesk/ogham @zendesk/two-brothers-ios @zendesk/adventure-ios 

## Risks
* None 
* Affected areas: Changed "init" method name from `init` to "initialize" to let Swift 5.x compile. The sample App's call to Connect initialisation was changed accordingly.

## To QA
1. If this PR is approved, you need to change one line on the Zendesk Connect iOS SDK Documentation (change "Connect.instance.init(...)" to "Connect.instance.initialize(...)".)
2. There might be a more elegant way but by putting Sample Project on Swift 5.0 (and keeping Pod on 4.2), Swift Compiler doesn't really like your use of "init" keyword!

This is related to bug #20 

Expected result: 
